### PR TITLE
Add German weekday abbreviations

### DIFF
--- a/client/pages/viewerpage/org_viewer.js
+++ b/client/pages/viewerpage/org_viewer.js
@@ -193,6 +193,7 @@ class OrgViewer extends React.Component {
 
             function day(n){
                 switch(navigator.language.split("-")[0]){
+                    case "de": ["So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"][n];
                     default: return ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"][n];
                 }
             }


### PR DESCRIPTION
On systems with German locales the weekdays abbreviation differs from the English format.